### PR TITLE
NG algorithm parametrization

### DIFF
--- a/src/orion/algo/nevergrad/nevergradoptimizer.py
+++ b/src/orion/algo/nevergrad/nevergradoptimizer.py
@@ -116,9 +116,11 @@ class NevergradOptimizer(BaseAlgorithm):
     requires_dist = None
     requires_shape = None
 
-    def __init__(self, space, seed=None, budget=100, num_workers=10):
+    def __init__(
+        self, space, model_name="NGOpt", seed=None, budget=100, num_workers=10
+    ):
         param = to_ng_space(space)
-        self.algo = ng.optimizers.NGOpt(
+        self.algo = ng.optimizers.registry[model_name](
             parametrization=param, budget=budget, num_workers=num_workers
         )
         self.algo.enable_pickling()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,7 +1,18 @@
 """Perform integration tests for `orion.algo.nevergrad`."""
+import nevergrad as ng
+import pytest
 from orion.benchmark.task.branin import Branin
 from orion.core.utils import backward
 from orion.testing.algo import BaseAlgoTests, phase
+
+# ModelNames = ng.optimizers.registry.keys()
+ModelNames = ["NGOpt", "RandomSearch"]
+
+
+@pytest.fixture(autouse=True, params=ModelNames)
+def _config(request):
+    """ Fixture that parametrizes the configuration used in the tests below. """
+    TestNevergradOptimizer.config["model_name"] = request.param
 
 
 # Test suite for algorithms. You may reimplement some of the tests to adapt them to your algorithm


### PR DESCRIPTION
NevergradOptimizer can instantiate any of the NG algorithm
test suite can run on several NG algorithms

_Hi there! Thank you for contributing. Feel free to use this pull request template; It helps us reviewing your work at its true value._

_Please remove the instructions in italics before posting the pull request :)._

# Description
_Describe what is the purpose of this pull request and why it should be integrated to the repository. 
When your changes modify the current behavior, explain why your solution is better._

_If it solves a GitHub issue, be sure to [link it](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests)._

# Changes
_Give an overview of the suggested solution._

# Checklist
_This is simply a reminder of what we are going to look for before merging your code._

_Add an `x` in the boxes that apply._
_If you're unsure about any of them, don't hesitate to ask. We're here to help!_ 
_You can also fill these out after creating the PR if it's a work in progress (be sure to publish the PR as a draft then)_

## Tests
- [ ] I added corresponding tests for bug fixes and new features. If possible, the tests fail without the changes
- [ ] All new and existing tests are passing (`$ tox -e py38`; replace `38` by your Python version if necessary)

## Documentation
- [ ] I have updated the relevant documentation related to my changes

## Quality
- [ ] I have read the [CONTRIBUTING](https://github.com/Epistimio/orion/blob/develop/CONTRIBUTING.md) doc
- [ ] My commits messages follow [this format](https://chris.beams.io/posts/git-commit/)
- [ ] My code follows the style guidelines (`$ tox -e lint`)

# Further comments
_Please include any additional information or comment that you feel will be helpful to the review of this pull request._
